### PR TITLE
14 openssl cant find distinguished name in config

### DIFF
--- a/conf/ecdh.cnf
+++ b/conf/ecdh.cnf
@@ -13,6 +13,8 @@ HOME			= .
 default_bits		= 384
 attributes		= req_attributes
 
+distinguished_name = req_distinguished_name
+
 # Stop confirmation prompts. All information is contained below.
 prompt			= no
 
@@ -24,6 +26,9 @@ string_mask         = nombstr
 
 [ req_attributes ]
 # None. Could put Challenge Passwords, don't want them, leave empty
+
+[ req_distinguished_name ]
+commonName              = VGZLGLQXVP
 
 [ v3_req ]
 

--- a/conf/ecdsa.cnf
+++ b/conf/ecdsa.cnf
@@ -13,6 +13,8 @@ HOME			= .
 default_bits		= 384
 attributes		= req_attributes
 
+distinguished_name = req_distinguished_name
+
 # Stop confirmation prompts. All information is contained below.
 prompt			= no
 
@@ -24,6 +26,9 @@ string_mask         = nombstr
 
 [ req_attributes ]
 # None. Could put Challenge Passwords, don't want them, leave empty
+
+[ req_distinguished_name ]
+commonName              = VGZLGLQXVP
 
 [ v3_req ]
 

--- a/conf/rsa.cnf
+++ b/conf/rsa.cnf
@@ -13,6 +13,8 @@ HOME			= .
 default_bits		= 4096
 attributes		= req_attributes
 
+distinguished_name = req_distinguished_name
+
 # Stop confirmation prompts. All information is contained below.
 prompt			= no
 
@@ -24,6 +26,9 @@ string_mask         = nombstr
 
 [ req_attributes ]
 # None. Could put Challenge Passwords, don't want them, leave empty
+
+[ req_distinguished_name ]
+commonName              = VGZLGLQXVP
 
 [ v3_req ]
 

--- a/tcra.sh
+++ b/tcra.sh
@@ -132,13 +132,16 @@ generate_private_key() {
 generate_csr() { 
     local str="PKCS#10 CSR generated, ${csr}"
     if [[ ${arg2} == "rsa" ]]; then 
-        openssl req -new -key "${pkey}" -nodes -out "${csr}" -sha384 -subj "/CN=${cn}" -config "${__conf}/rsa.cnf"
+        sed -i -E "s/^(commonName[[:blank:]]*=[[:blank:]]*).*/\1${cn}/" ${__conf}/rsa.cnf
+        openssl req -new -key "${pkey}" -nodes -out "${csr}" -sha384 -config "${__conf}/rsa.cnf"
         printf "%(%Y-%m-%dT%H:%M:%SZ)T $$ [info] %s\n" $(date +%s) "${str}"
     elif [[ ${arg2} == "ecdsa" ]]; then
-        openssl req -new -key "${pkey}" -nodes -out "${csr}" -sha384 -subj "/CN=${cn}" -config "${__conf}/ecdsa.cnf"
+        sed -i -E "s/^(commonName[[:blank:]]*=[[:blank:]]*).*/\1${cn}/" ${__conf}/ecdsa.cnf
+        openssl req -new -key "${pkey}" -nodes -out "${csr}" -sha384 -config "${__conf}/ecdsa.cnf"
         printf "%(%Y-%m-%dT%H:%M:%SZ)T $$ [info] %s\n" $(date +%s) "${str}"
     elif [[ ${arg2} == "ecdh" ]]; then
-        openssl req -new -key "${pkey}" -nodes -out "${csr}" -sha384 -subj "/CN=${cn}" -config "${__conf}/ecdh.cnf"
+        sed -i -E "s/^(commonName[[:blank:]]*=[[:blank:]]*).*/\1${cn}/" ${__conf}/ecdh.cnf
+        openssl req -new -key "${pkey}" -nodes -out "${csr}" -sha384 -config "${__conf}/ecdh.cnf"
         printf "%(%Y-%m-%dT%H:%M:%SZ)T $$ [info] %s\n" $(date +%s) "${str}"
     else
         printf "%(%Y-%m-%dT%H:%M:%SZ)T $$ [error] %s\n" $(date +%s) "Unrecognized argument, ${arg2}, exiting."


### PR DESCRIPTION
Replaced inline subject with commonName key/value pair in openssl cnf.  This fix ensure backwards compatibility with OpenSSL 1.0.x